### PR TITLE
Moved clear terminal to bottom

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,6 @@ use notify_rust::Notification;
 use timers::Config;
 
 fn main() {
-    // clear terminal
-    print!("\x1B[2J\x1B[1;1H");
 
     let cmd = Command::new("timer")
         .author("Vivek R, 123vivekr@gmail.com")
@@ -24,6 +22,9 @@ fn main() {
     let output_filename = cmd.get_one::<String>("output").map(|s| s.to_string());
 
     let config = Config::new(time_string, output_filename);
+
+    // clear terminal
+    print!("\x1B[2J\x1B[1;1H");
 
     timers::run(config);
 


### PR DESCRIPTION
This commit may seem kinda useless, but I moved the print() that cleared the terminal just above timers::run, cause whenever i run `./timers` or `./timers -h`, i can't see the helptext.

Bear with me, cause I don't know anything about Rust.